### PR TITLE
make examples compliant with cocotb 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Installation
 The easiest way to start using VeRLPy is to install it using `pip install verlpy`
 
-VeRLPy is currently dependent on OpenAI [Gym](https://gym.openai.com/), [cocotb](https://docs.cocotb.org/en/stable/) and [Stable Baselines3](https://stable-baselines3.readthedocs.io/en/master/). These packages should get installed alongside VeRLPy when installing using `pip`. For running the verification, a simulator compatible with cocotb is additionally required. Please refer to the official  [cocotb](https://docs.cocotb.org/en/stable/) documentation to set this up.
+VeRLPy is currently dependent on OpenAI [Gym](https://gym.openai.com/), [cocotb](https://docs.cocotb.org/en/stable/), [cocotb-bus](https://github.com/cocotb/cocotb-bus), and [Stable Baselines3](https://stable-baselines3.readthedocs.io/en/master/). These packages should get installed alongside VeRLPy when installing using `pip`. For running the verification, a simulator compatible with cocotb is additionally required. Please refer to the official  [cocotb](https://docs.cocotb.org/en/stable/) documentation to set this up.
 
 ## Usage Guide
 Having familiarity with [cocotb](https://docs.cocotb.org/en/stable/), OpenAI [Gym](https://gym.openai.com/) and [this whitepaper on VeRLPy](https://arxiv.org/abs/2108.03978) will be very beneficial to get started with the VeRLPy library.

--- a/examples/COO_compressor/tb_with_rl/test_coo_compressor_helper.py
+++ b/examples/COO_compressor/tb_with_rl/test_coo_compressor_helper.py
@@ -1,9 +1,9 @@
 from cocotb.decorators import coroutine
 from cocotb.triggers import RisingEdge
-from cocotb.monitors import BusMonitor
-from cocotb.drivers import BusDriver
+from cocotb_bus.monitors import BusMonitor
+from cocotb_bus.drivers import BusDriver
 from cocotb.binary import BinaryValue
-from cocotb.scoreboard import Scoreboard
+from cocotb_bus.scoreboard import Scoreboard
 
 
 class Driver(BusDriver):

--- a/examples/COO_compressor/tb_without_rl/test_coo_compressor_cocotb.py
+++ b/examples/COO_compressor/tb_without_rl/test_coo_compressor_cocotb.py
@@ -4,11 +4,11 @@ import cocotb
 import logging as log
 from cocotb.decorators import coroutine
 from cocotb.triggers import Timer, RisingEdge, FallingEdge
-from cocotb.monitors import BusMonitor
-from cocotb.drivers import BusDriver
+from cocotb_bus.monitors import BusMonitor
+from cocotb_bus.drivers import BusDriver
 from cocotb.binary import BinaryValue
 from cocotb.regression import TestFactory
-from cocotb.scoreboard import Scoreboard
+from cocotb_bus.scoreboard import Scoreboard
 from cocotb.result import TestFailure
 from cocotb.clock import Clock
 

--- a/examples/COO_decompressor/tb_with_rl/test_coo_decompressor_helper.py
+++ b/examples/COO_decompressor/tb_with_rl/test_coo_decompressor_helper.py
@@ -1,10 +1,10 @@
 import cocotb
 from cocotb.decorators import coroutine
 from cocotb.triggers import Timer, RisingEdge, FallingEdge
-from cocotb.monitors import BusMonitor
-from cocotb.drivers import BusDriver
+from cocotb_bus.monitors import BusMonitor
+from cocotb_bus.drivers import BusDriver
 from cocotb.binary import BinaryValue
-from cocotb.scoreboard import Scoreboard
+from cocotb_bus.scoreboard import Scoreboard
 
 class Driver(BusDriver):
     _signals = [

--- a/examples/COO_decompressor/tb_without_rl/test_coo_decompression.py
+++ b/examples/COO_decompressor/tb_without_rl/test_coo_decompression.py
@@ -4,11 +4,11 @@ import cocotb
 import logging as log
 from cocotb.decorators import coroutine
 from cocotb.triggers import Timer, RisingEdge, FallingEdge
-from cocotb.monitors import BusMonitor
-from cocotb.drivers import BusDriver
+from cocotb_bus.monitors import BusMonitor
+from cocotb_bus.drivers import BusDriver
 from cocotb.binary import BinaryValue
 from cocotb.regression import TestFactory
-from cocotb.scoreboard import Scoreboard
+from cocotb_bus.scoreboard import Scoreboard
 from cocotb.result import TestFailure
 from cocotb.clock import Clock
 

--- a/examples/RLE_compressor/tb_with_rl/test_rle_compressor_helper.py
+++ b/examples/RLE_compressor/tb_with_rl/test_rle_compressor_helper.py
@@ -1,9 +1,9 @@
 from cocotb.decorators import coroutine
 from cocotb.triggers import RisingEdge
-from cocotb.monitors import BusMonitor
-from cocotb.drivers import BusDriver
+from cocotb_bus.monitors import BusMonitor
+from cocotb_bus.drivers import BusDriver
 from cocotb.binary import BinaryValue
-from cocotb.scoreboard import Scoreboard
+from cocotb_bus.scoreboard import Scoreboard
 
 # Parameters : In width - 16, out width - 32, coordinate - 15
 

--- a/examples/RLE_compressor/tb_without_rl/test_rle_compression.py
+++ b/examples/RLE_compressor/tb_without_rl/test_rle_compression.py
@@ -4,11 +4,11 @@ import cocotb
 import logging as log
 from cocotb.decorators import coroutine
 from cocotb.triggers import Timer, RisingEdge, FallingEdge
-from cocotb.monitors import BusMonitor
-from cocotb.drivers import BusDriver
+from cocotb_bus.monitors import BusMonitor
+from cocotb_bus.drivers import BusDriver
 from cocotb.binary import BinaryValue
 from cocotb.regression import TestFactory
-from cocotb.scoreboard import Scoreboard
+from cocotb_bus.scoreboard import Scoreboard
 from cocotb.result import TestFailure
 from cocotb.clock import Clock
 

--- a/examples/RLE_decompressor/tb_with_rl/test_rle_decompressor_helper.py
+++ b/examples/RLE_decompressor/tb_with_rl/test_rle_decompressor_helper.py
@@ -1,10 +1,10 @@
 import cocotb
 from cocotb.decorators import coroutine
 from cocotb.triggers import Timer, RisingEdge, FallingEdge
-from cocotb.monitors import BusMonitor
-from cocotb.drivers import BusDriver
+from cocotb_bus.monitors import BusMonitor
+from cocotb_bus.drivers import BusDriver
 from cocotb.binary import BinaryValue
-from cocotb.scoreboard import Scoreboard
+from cocotb_bus.scoreboard import Scoreboard
 
 class Driver(BusDriver):
     _signals = [

--- a/examples/RLE_decompressor/tb_without_rl/test_rle_decompression.py
+++ b/examples/RLE_decompressor/tb_without_rl/test_rle_decompression.py
@@ -4,11 +4,11 @@ import cocotb
 import logging as log
 from cocotb.decorators import coroutine
 from cocotb.triggers import Timer, RisingEdge, FallingEdge
-from cocotb.monitors import BusMonitor
-from cocotb.drivers import BusDriver
+from cocotb_bus.monitors import BusMonitor
+from cocotb_bus.drivers import BusDriver
 from cocotb.binary import BinaryValue
 from cocotb.regression import TestFactory
-from cocotb.scoreboard import Scoreboard
+from cocotb_bus.scoreboard import Scoreboard
 from cocotb.result import TestFailure
 from cocotb.clock import Clock
 

--- a/examples/axi4_fabric_rl/test_axi_fabric_helper.py
+++ b/examples/axi4_fabric_rl/test_axi_fabric_helper.py
@@ -1,6 +1,6 @@
 import cocotb
 from cocotb.triggers import Timer, RisingEdge
-from cocotb.drivers import BusDriver
+from cocotb_bus.drivers import BusDriver
 from cocotb.binary import BinaryValue
 
 s0_resp_delay = 10

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ packages = find:
 python_requires = >=3.6
 install_requires = 
     cocotb
+    cocotb[bus]
     gym
     stable_baselines3
     matplotlib


### PR DESCRIPTION
Several subpackages & modules that were previously located at cocotb, are placed in cocotb_bus package now. The commit makes project examples to be compilant with cocotb 1.7.0
